### PR TITLE
Discard use of first-person pronouns in homepage

### DIFF
--- a/templates/home.html
+++ b/templates/home.html
@@ -4,7 +4,7 @@
 <h2 id="title">MSPA TO GO</h2>
 <div id="content">
     <p class="comic-text">
-        MSPA To Go is a webserver that serves pages from MS Paint Adventures in a format
+        MSPA To Go is an application server that serves pages from MS Paint Adventures in a format
         digestible on mobile phones. With the redirection of the original MS Paint Adventures
         site to the VIZ Media-run site, and the VIZ Media site's constant HTTP 500 errors, there
         is no good way to read MSPA on mobile. At least there wasn't until now!
@@ -12,7 +12,7 @@
         Not familiar with MSPA page numbers? VIZ page numbers will redirect you to the right MSPA
         page! For example, /homestuck/1 will take you to /read/6/001901.
         <br><br>
-        MS Paint Adventures is the work of Andrew Hussie, and I am not associated with MS Paint Adventures,
+        MS Paint Adventures is the work of Andrew Hussie, and this website's operator is not associated with MS Paint Adventures,
         What Pumpkin, VIZ Media, or the Homestuck Independent Creative Union. MSPA To Go is made out of love
         for MSPA and a desire for it to be accessible to those using mobile devices.
     </p>


### PR DESCRIPTION
Full commit message: MSPAToGo is reaching far more people than I honestly thought would happen, so I'm punching in my part-time GitHub timesheet to fix a mild grammatical issue, and then be slightly pedantic about words.

The pull request itself will be set as a draft until I can confirm that the changes (1) to the HTML don't make everything explode.